### PR TITLE
Remove jasmine peerDependency. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+0.2.3
+=====
+  * Remove `jasmine` from the `peerDependencies` list
+    * Jasmine is implicity with the library
+    * the peerDep caused issues with npm2 and jest
+
 0.2.2
 =====
 0.2.1 was a failed release

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "author": "Blaine Kasten<blainekasten@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "jasmine": "1.x || 2.x",
     "enzyme": "1.x || 2.x"
   },
   "devDependencies": {


### PR DESCRIPTION
It's implicit and causes errors with npm2 + enzyme