### PR TITLE
Fixes publishrc to not need a git tag

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -1,11 +1,11 @@
 {
   "validations": {
     "vulnerableDependencies": true,
-    "uncommittedChanges": true,
+    "uncommittedChanges": false,
     "untrackedFiles": false,
     "sensitiveData": true,
     "branch": "master",
-    "gitTag": true
+    "gitTag": false
   },
   "confirm": true,
   "publishTag": "latest",


### PR DESCRIPTION
I couldn't understand what wasn't working. So just turning off this validation.