### PR TITLE
Enhance negated messages

### DIFF
--- a/src/addMatcher.js
+++ b/src/addMatcher.js
@@ -5,10 +5,13 @@
  * @providesModule addMatcher
  */
 
+import type { MatcherObject } from './types/MatcherObject';
+
+
 const coreMatchers = jasmine.matchers;
 let errorThrown = false;
 
-export default function addMatcher(matcher: Object) : void {
+export default function addMatcher(matcher: MatcherObject) : void {
   const matcherName = Object.keys(matcher)[0];
 
   /*

--- a/src/assertions/__tests__/toBeChecked--tests.js
+++ b/src/assertions/__tests__/toBeChecked--tests.js
@@ -1,5 +1,9 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
+const { toBeChecked } = require('../toBeChecked');
+
+const { compare, negativeCompare }= toBeChecked();
+
 
 function Fixture() {
   return (
@@ -12,23 +16,57 @@ function Fixture() {
 }
 
 describe('toBeChecked', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#checked')).toBeChecked();
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#checked')).toBeChecked();
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('#checked')).toBeChecked();
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#not')).not.toBeChecked();
+    });
+
+    it('can be defaultChecked, currently not checked, and know to say its not checked', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#tertiary')).not.toBeChecked();
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('#checked')).toBeChecked();
-  });
+  describe('unit-tests', () => {
+    describe('compare', () => {
+      const wrapper = shallow(<Fixture />);
+      const truthyResults = compare(wrapper.find('#checked'));
+      const falsyResults = compare(wrapper.find('#not'));
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#not')).not.toBeChecked();
-  });
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
 
-  it('can be defaultChecked, currently not checked, and know to say its not checked', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#tertiary')).not.toBeChecked();
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('negativeCompare', () => {
+      const wrapper = shallow(<Fixture />);
+      const falsyResults = negativeCompare(wrapper.find('#checked'));
+      const truthyResults = negativeCompare(wrapper.find('#not'));
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toBeChecked--tests.js
+++ b/src/assertions/__tests__/toBeChecked--tests.js
@@ -1,8 +1,10 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
-const { toBeChecked } = require('../toBeChecked');
 
-const { compare, negativeCompare }= toBeChecked();
+const {
+  compare: toBeChecked,
+  negativeCompare: notToBeChecked
+} = require('../toBeChecked').toBeChecked();
 
 
 function Fixture() {
@@ -39,10 +41,10 @@ describe('toBeChecked', () => {
   });
 
   describe('unit-tests', () => {
-    describe('compare', () => {
+    describe('toBeChecked', () => {
       const wrapper = shallow(<Fixture />);
-      const truthyResults = compare(wrapper.find('#checked'));
-      const falsyResults = compare(wrapper.find('#not'));
+      const truthyResults = toBeChecked(wrapper.find('#checked'));
+      const falsyResults = toBeChecked(wrapper.find('#not'));
 
       it('passes when true', () => {
         expect(truthyResults.pass).toBeTruthy();
@@ -54,10 +56,10 @@ describe('toBeChecked', () => {
       });
     });
 
-    describe('negativeCompare', () => {
+    describe('notToBeChecked', () => {
       const wrapper = shallow(<Fixture />);
-      const falsyResults = negativeCompare(wrapper.find('#checked'));
-      const truthyResults = negativeCompare(wrapper.find('#not'));
+      const falsyResults = notToBeChecked(wrapper.find('#checked'));
+      const truthyResults = notToBeChecked(wrapper.find('#not'));
 
       it('passes when false', () => {
         expect(falsyResults.pass).toBeFalsy();

--- a/src/assertions/__tests__/toBeChecked--tests.js
+++ b/src/assertions/__tests__/toBeChecked--tests.js
@@ -3,7 +3,7 @@ const React = require('react');
 
 const {
   compare: toBeChecked,
-  negativeCompare: notToBeChecked
+  negativeCompare: notToBeChecked,
 } = require('../toBeChecked').toBeChecked();
 
 
@@ -52,7 +52,7 @@ describe('toBeChecked', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -67,7 +67,7 @@ describe('toBeChecked', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toBeDisabled--tests.js
+++ b/src/assertions/__tests__/toBeDisabled--tests.js
@@ -1,8 +1,10 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
-const { toBeDisabled } = require('../toBeDisabled');
 
-const { compare, negativeCompare } = toBeDisabled();
+const {
+  compare: toBeDisabled,
+  negativeCompare: notToBeDisabled
+} = require('../toBeDisabled').toBeDisabled();
 
 function Fixture() {
   return (
@@ -32,10 +34,10 @@ describe('toBeDisabled', () => {
   });
 
   describe('unit-tests', () => {
-    describe('compare', () => {
+    describe('toBeDisabled', () => {
       const wrapper = shallow(<Fixture />);
-      const truthyResults = compare(wrapper.find('#disabled'));
-      const falsyResults = compare(wrapper.find('#not'));
+      const truthyResults = toBeDisabled(wrapper.find('#disabled'));
+      const falsyResults = toBeDisabled(wrapper.find('#not'));
 
       it('passes when true', () => {
         expect(truthyResults.pass).toBeTruthy();
@@ -47,10 +49,10 @@ describe('toBeDisabled', () => {
       });
     });
 
-    describe('negativeCompare', () => {
+    describe('notToBeDisabled', () => {
       const wrapper = shallow(<Fixture />);
-      const falsyResults = negativeCompare(wrapper.find('#disabled'));
-      const truthyResults = negativeCompare(wrapper.find('#not'));
+      const falsyResults = notToBeDisabled(wrapper.find('#disabled'));
+      const truthyResults = notToBeDisabled(wrapper.find('#not'));
 
       it('passes when false', () => {
         expect(falsyResults.pass).toBeFalsy();

--- a/src/assertions/__tests__/toBeDisabled--tests.js
+++ b/src/assertions/__tests__/toBeDisabled--tests.js
@@ -1,5 +1,8 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
+const { toBeDisabled } = require('../toBeDisabled');
+
+const { compare, negativeCompare } = toBeDisabled();
 
 function Fixture() {
   return (
@@ -11,18 +14,52 @@ function Fixture() {
 }
 
 describe('toBeDisabled', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#disabled')).toBeDisabled();
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#disabled')).toBeDisabled();
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('#disabled')).toBeDisabled();
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#not')).not.toBeDisabled();
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('#disabled')).toBeDisabled();
-  });
+  describe('unit-tests', () => {
+    describe('compare', () => {
+      const wrapper = shallow(<Fixture />);
+      const truthyResults = compare(wrapper.find('#disabled'));
+      const falsyResults = compare(wrapper.find('#not'));
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#not')).not.toBeDisabled();
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
+
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('negativeCompare', () => {
+      const wrapper = shallow(<Fixture />);
+      const falsyResults = negativeCompare(wrapper.find('#disabled'));
+      const truthyResults = negativeCompare(wrapper.find('#not'));
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toBeDisabled--tests.js
+++ b/src/assertions/__tests__/toBeDisabled--tests.js
@@ -3,7 +3,7 @@ const React = require('react');
 
 const {
   compare: toBeDisabled,
-  negativeCompare: notToBeDisabled
+  negativeCompare: notToBeDisabled,
 } = require('../toBeDisabled').toBeDisabled();
 
 function Fixture() {
@@ -45,7 +45,7 @@ describe('toBeDisabled', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -60,7 +60,7 @@ describe('toBeDisabled', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toBeEmpty--tests.js
+++ b/src/assertions/__tests__/toBeEmpty--tests.js
@@ -3,16 +3,13 @@ const React = require('react');
 
 const {
   compare: toBeEmpty,
-  negateCompare: notToBeEmpty
+  negativeCompare: notToBeEmpty
 } = require('../toBeEmpty').toBeEmpty();
 
 function Fixture() {
   return (
     <div>
-      <span className="isEmpty" />
-      <span className="hasChildren">
-        <a/>
-      </span>
+      <span className="matches" />
     </div>
   );
 }
@@ -21,25 +18,25 @@ describe('toBeEmpty', () => {
   describe('integration', () => {
     it('works with `shallow` renders', () => {
       const wrapper = shallow(<Fixture />);
-      expect(wrapper.find('.isEmpty')).toBeEmpty();
+      expect(wrapper.find('.doesnt-match')).toBeEmpty();
     });
 
     it('works with `mount` renders', () => {
       const wrapper = mount(<Fixture />);
-      expect(wrapper.find('.isEmpty')).toBeEmpty();
+      expect(wrapper.find('.doesnt-match')).toBeEmpty();
     });
 
     it('works with with jasmines negation', () => {
       const wrapper = shallow(<Fixture />);
-      expect(wrapper.find('.hasChildren')).not.toBeEmpty();
+      expect(wrapper.find('.matches')).not.toBeEmpty();
     });
   });
 
   describe('unit-tests', () => {
     describe('toBeEmpty', () => {
       const wrapper = shallow(<Fixture />);
-      const truthyResults = toBeEmpty(wrapper.find('.isEmpty'));
-      const falsyResults = toBeEmpty(wrapper.find('.hasChildren'));
+      const truthyResults = toBeEmpty(wrapper.find('.doesnt-match'));
+      const falsyResults = toBeEmpty(wrapper.find('.matches'));
 
       it('passes when true', () => {
         expect(truthyResults.pass).toBeTruthy();
@@ -53,8 +50,8 @@ describe('toBeEmpty', () => {
 
     describe('notToBeEmpty', () => {
       const wrapper = shallow(<Fixture />);
-      const falsyResults = notToBeEmpty(wrapper.find('.isEmpty'));
-      const truthyResults = notToBeEmpty(wrapper.find('.hasChildren'));
+      const falsyResults = notToBeEmpty(wrapper.find('.doesnt-match'));
+      const truthyResults = notToBeEmpty(wrapper.find('.matches'));
 
       it('passes when false', () => {
         expect(falsyResults.pass).toBeFalsy();

--- a/src/assertions/__tests__/toBeEmpty--tests.js
+++ b/src/assertions/__tests__/toBeEmpty--tests.js
@@ -3,7 +3,7 @@ const React = require('react');
 
 const {
   compare: toBeEmpty,
-  negativeCompare: notToBeEmpty
+  negativeCompare: notToBeEmpty,
 } = require('../toBeEmpty').toBeEmpty();
 
 function Fixture() {
@@ -44,7 +44,7 @@ describe('toBeEmpty', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -59,7 +59,7 @@ describe('toBeEmpty', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toBeEmpty--tests.js
+++ b/src/assertions/__tests__/toBeEmpty--tests.js
@@ -1,28 +1,69 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toBeEmpty,
+  negateCompare: notToBeEmpty
+} = require('../toBeEmpty').toBeEmpty();
+
 function Fixture() {
   return (
     <div>
-      <span className="foo" />
-      <span className="bar baz" />
+      <span className="isEmpty" />
+      <span className="hasChildren">
+        <a/>
+      </span>
     </div>
   );
 }
 
 describe('toBeEmpty', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('ul')).toBeEmpty();
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('.isEmpty')).toBeEmpty();
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('.isEmpty')).toBeEmpty();
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('.hasChildren')).not.toBeEmpty();
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('ul')).toBeEmpty();
-  });
+  describe('unit-tests', () => {
+    describe('toBeEmpty', () => {
+      const wrapper = shallow(<Fixture />);
+      const truthyResults = toBeEmpty(wrapper.find('.isEmpty'));
+      const falsyResults = toBeEmpty(wrapper.find('.hasChildren'));
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('span')).not.toBeEmpty();
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
+
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('notToBeEmpty', () => {
+      const wrapper = shallow(<Fixture />);
+      const falsyResults = notToBeEmpty(wrapper.find('.isEmpty'));
+      const truthyResults = notToBeEmpty(wrapper.find('.hasChildren'));
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toBePresent--tests.js
+++ b/src/assertions/__tests__/toBePresent--tests.js
@@ -1,28 +1,66 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toBePresent,
+  negativeCompare: notToBePresent,
+} = require('../toBePresent').toBePresent();
+
 function Fixture() {
   return (
     <div>
-      <span className="foo" />
-      <span className="bar baz" />
+      <span className="matches" />
     </div>
   );
 }
 
 describe('toBePresent', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('span')).toBePresent();
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('span')).toBePresent();
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('span')).toBePresent();
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('ul')).not.toBePresent();
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('span')).toBePresent();
-  });
+  describe('unit-tests', () => {
+    describe('toBePresent', () => {
+      const wrapper = shallow(<Fixture />);
+      const truthyResults = toBePresent(wrapper.find('.matches'));
+      const falsyResults = toBePresent(wrapper.find('.doesnt-matches'));
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('ul')).not.toBePresent();
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
+
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('notToBePresent', () => {
+      const wrapper = shallow(<Fixture />);
+      const falsyResults = notToBePresent(wrapper.find('.matches'));
+      const truthyResults = notToBePresent(wrapper.find('.doesnt-match'));
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toBePresent--tests.js
+++ b/src/assertions/__tests__/toBePresent--tests.js
@@ -44,7 +44,7 @@ describe('toBePresent', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -59,7 +59,7 @@ describe('toBePresent', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toContainReact--tests.js
+++ b/src/assertions/__tests__/toContainReact--tests.js
@@ -57,7 +57,7 @@ describe('toContainReact', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -72,7 +72,7 @@ describe('toContainReact', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toContainReact--tests.js
+++ b/src/assertions/__tests__/toContainReact--tests.js
@@ -1,6 +1,11 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toContainReact,
+  negativeCompare: notToContainReact,
+} = require('../toContainReact').toContainReact();
+
 function User(props) {
   return (
     <span>User {props.index}</span>
@@ -23,18 +28,52 @@ function Fixture() {
 }
 
 describe('toContainReact', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper).toContainReact(<User index={1} />);
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper).toContainReact(<User index={1} />);
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper).toContainReact(<User index={1} />);
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper).not.toContainReact(<User index={3} />);
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper).toContainReact(<User index={1} />);
-  });
+  describe('unit-tests', () => {
+    describe('toContainReact', () => {
+      const wrapper = shallow(<Fixture />);
+      const truthyResults = toContainReact(wrapper, <User index={1} />);
+      const falsyResults = toContainReact(wrapper, <User index={3} />);
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper).not.toContainReact(<User index={3} />);
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
+
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('notToContainReact', () => {
+      const wrapper = shallow(<Fixture />);
+      const falsyResults = notToContainReact(wrapper, <User index={1} />);
+      const truthyResults = notToContainReact(wrapper, <User index={3} />);
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toHaveClassName--tests.js
+++ b/src/assertions/__tests__/toHaveClassName--tests.js
@@ -47,7 +47,7 @@ describe('toHaveClassName', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -62,7 +62,7 @@ describe('toHaveClassName', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toHaveClassName--tests.js
+++ b/src/assertions/__tests__/toHaveClassName--tests.js
@@ -1,6 +1,11 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toHaveClassName,
+  negativeCompare: notToHaveClassName,
+} = require('../toHaveClassName').toHaveClassName();
+
 function Fixture() {
   return (
     <div>
@@ -11,20 +16,54 @@ function Fixture() {
 }
 
 describe('toHaveClassName', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('.foo')).toHaveClassName('foo');
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('.foo')).toHaveClassName('foo');
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('.bar')).toHaveClassName('bar baz');
+      expect(wrapper.find('.bar')).toHaveClassName('bar');
+      expect(wrapper.find('.bar')).toHaveClassName('baz');
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('.bar')).not.toHaveClassName('balsdfja');
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('.bar')).toHaveClassName('bar baz');
-    expect(wrapper.find('.bar')).toHaveClassName('bar');
-    expect(wrapper.find('.bar')).toHaveClassName('baz');
-  });
+  describe('unit-tests', () => {
+    describe('toHaveClassName', () => {
+      const wrapper = shallow(<Fixture />);
+      const truthyResults = toHaveClassName(wrapper.find('.bar'), 'bar');
+      const falsyResults = toHaveClassName(wrapper.find('.bar'), 'asldfkj');
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('.bar')).not.toHaveClassName('balsdfja');
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
+
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('notToHaveClassName', () => {
+      const wrapper = shallow(<Fixture />);
+      const falsyResults = notToHaveClassName(wrapper.find('.bar'), 'bar');
+      const truthyResults = notToHaveClassName(wrapper.find('.bar'), 'asdfl');
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toHaveHTML--tests.js
+++ b/src/assertions/__tests__/toHaveHTML--tests.js
@@ -55,7 +55,7 @@ describe('toHaveHTML', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -70,7 +70,7 @@ describe('toHaveHTML', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toHaveHTML--tests.js
+++ b/src/assertions/__tests__/toHaveHTML--tests.js
@@ -1,6 +1,11 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toHaveHTML,
+  negativeCompare: notToHaveHTML,
+} = require('../toHaveHTML').toHaveHTML();
+
 function Fixture() {
   return (
     <div id="root">
@@ -9,34 +14,64 @@ function Fixture() {
   );
 }
 
+const html = '<span id="child">Test</span>';
+
 describe('toHaveHTML', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#child')).toHaveHTML(
-      '<span id="child">Test</span>'
-    );
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#child')).toHaveHTML(html);
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('#child')).toHaveHTML(html);
+    });
+
+    it('normalizes the quotations used', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#child')).toHaveHTML(html);
+
+      expect(wrapper.find('#child')).toHaveHTML(
+        '<span id=\'child\'>Test</span>'
+      );
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#child')).not.toHaveHTML('foo');
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('#child')).toHaveHTML(
-      '<span id="child">Test</span>'
-    );
-  });
+  describe('unit-tests', () => {
+    describe('toHaveHTML', () => {
+      const wrapper = shallow(<Fixture />);
+      const truthyResults = toHaveHTML(wrapper.find('#child'), html);
+      const falsyResults = toHaveHTML(wrapper.find('#child'), 'foo');
 
-  it('normalizes the quotations used', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#child')).toHaveHTML(
-      '<span id="child">Test</span>'
-    );
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
 
-    expect(wrapper.find('#child')).toHaveHTML(
-      '<span id=\'child\'>Test</span>'
-    );
-  });
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#child')).not.toHaveHTML('foo');
+    describe('notToHaveHTML', () => {
+      const wrapper = shallow(<Fixture />);
+      const falsyResults = notToHaveHTML(wrapper.find('#child'), html);
+      const truthyResults = notToHaveHTML(wrapper.find('#child'), 'foo');
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toHaveProp--tests.js
+++ b/src/assertions/__tests__/toHaveProp--tests.js
@@ -1,6 +1,11 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toHaveProp,
+  negativeCompare: notToHaveProp,
+} = require('../toHaveProp').toHaveProp(jasmine.matchersUtil, []);
+
 function User(props) {
   return (
     <div>
@@ -35,44 +40,78 @@ function Fixture() {
 }
 
 describe('toHaveProp', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find(User)).toHaveProp('name');
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find(User)).toHaveProp('name');
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find(User)).toHaveProp('name');
+    });
+
+    it('can validate the value also', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find(User)).toHaveProp('name', 'blaine');
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find(User)).not.toHaveProp('name', 'blaine kasten');
+      expect(wrapper.find(User)).not.toHaveProp('foo');
+    });
+
+    it('can validate arrays', () => {
+      const wrapper = shallow(<Fixture />);
+
+      expect(wrapper.find(User)).toHaveProp('arrayProp', [1, 2, 3]);
+      expect(wrapper.find(User)).not.toHaveProp('arrayProp', [4, 5, 6]);
+    });
+
+    it('can validate objects', () => {
+      const wrapper = shallow(<Fixture />);
+
+      expect(wrapper.find(User)).toHaveProp('objectProp', { foo: 'bar' });
+      expect(wrapper.find(User)).not.toHaveProp('objectProp', { foo: 'baz' });
+    });
+
+    it('works with falsy props', () => {
+      const wrapper = shallow(<Fixture />);
+
+      expect(wrapper.find(User)).toHaveProp('falsy', false);
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find(User)).toHaveProp('name');
-  });
+  describe('unit-tests', () => {
+    describe('toHaveProp', () => {
+      const wrapper = shallow(<Fixture />);
+      const truthyResults = toHaveProp(wrapper.find(User), 'name', 'blaine');
+      const falsyResults = toHaveProp(wrapper.find(User), 'name', 'jon');
 
-  it('can validate the value also', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find(User)).toHaveProp('name', 'blaine');
-  });
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find(User)).not.toHaveProp('name', 'blaine kasten');
-    expect(wrapper.find(User)).not.toHaveProp('foo');
-  });
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
 
-  it('can validate arrays', () => {
-    const wrapper = shallow(<Fixture />);
+    describe('notToHaveProp', () => {
+      const wrapper = shallow(<Fixture />);
+      const falsyResults = notToHaveProp(wrapper.find(User), 'name', 'blaine');
+      const truthyResults = notToHaveProp(wrapper.find(User), 'name', 'jon');
 
-    expect(wrapper.find(User)).toHaveProp('arrayProp', [1, 2, 3]);
-    expect(wrapper.find(User)).not.toHaveProp('arrayProp', [4, 5, 6]);
-  });
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
 
-  it('can validate objects', () => {
-    const wrapper = shallow(<Fixture />);
-
-    expect(wrapper.find(User)).toHaveProp('objectProp', { foo: 'bar' });
-    expect(wrapper.find(User)).not.toHaveProp('objectProp', { foo: 'baz' });
-  });
-
-  it('works with falsy props', () => {
-    const wrapper = shallow(<Fixture />);
-
-    expect(wrapper.find(User)).toHaveProp('falsy', false);
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toHaveProp--tests.js
+++ b/src/assertions/__tests__/toHaveProp--tests.js
@@ -95,7 +95,7 @@ describe('toHaveProp', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -110,7 +110,7 @@ describe('toHaveProp', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toHaveRef--tests.js
+++ b/src/assertions/__tests__/toHaveRef--tests.js
@@ -49,7 +49,7 @@ describe('toHaveRef', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -64,7 +64,7 @@ describe('toHaveRef', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toHaveRef--tests.js
+++ b/src/assertions/__tests__/toHaveRef--tests.js
@@ -1,6 +1,10 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
-const { toHaveRef } = require.requireActual('../toHaveRef');
+
+const {
+  compare: toHaveRef,
+  negativeCompare: notToHaveRef,
+} = require('../toHaveRef').toHaveRef(jasmine.matchersUtil, []);
 
 class Fixture extends React.Component {
   render() {
@@ -13,22 +17,55 @@ class Fixture extends React.Component {
 }
 
 describe('toHaveRef', () => {
-  it('fails with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
+  describe('integration', () => {
+    it('fails with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
 
-    const { compare } = toHaveRef();
-    const results = compare(wrapper, 'child');
+      const results = toHaveRef(wrapper, 'child');
 
-    expect(results.pass).toBeFalsy();
+      expect(results.pass).toBeFalsy();
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper).toHaveRef('child');
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper).not.toHaveRef('foo');
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper).toHaveRef('child');
-  });
+  describe('unit-tests', () => {
+    describe('toHaveRef', () => {
+      const wrapper = mount(<Fixture />);
+      const truthyResults = toHaveRef(wrapper, 'child');
+      const falsyResults = toHaveRef(wrapper, 'dad');
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper).not.toHaveRef('foo');
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
+
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('notToHaveRef', () => {
+      const wrapper = mount(<Fixture />);
+      const falsyResults = notToHaveRef(wrapper, 'child');
+      const truthyResults = notToHaveRef(wrapper, 'dad');
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toHaveState--tests.js
+++ b/src/assertions/__tests__/toHaveState--tests.js
@@ -1,6 +1,11 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toHaveState,
+  negativeCompare: notToHaveState,
+} = require('../toHaveState').toHaveState(jasmine.matchersUtil, []);
+
 class Fixture extends React.Component {
   constructor() {
     super();
@@ -19,36 +24,70 @@ class Fixture extends React.Component {
 }
 
 describe('toHaveState', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper).toHaveState('foo');
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper).toHaveState('foo');
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper).toHaveState('foo');
+    });
+
+    it('can validate the value also', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper).toHaveState('foo', false);
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+
+      expect(wrapper).not.toHaveState('foo', true);
+    });
+
+    it('can validate arrays', () => {
+      const wrapper = shallow(<Fixture />);
+
+      expect(wrapper).toHaveState('array', [1, 2, 3]);
+    });
+
+    it('can validate objects', () => {
+      const wrapper = shallow(<Fixture />);
+
+      expect(wrapper).toHaveState('object', { foo: 'bar' });
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper).toHaveState('foo');
-  });
+  describe('unit-tests', () => {
+    describe('toHaveState', () => {
+      const wrapper = mount(<Fixture />);
+      const truthyResults = toHaveState(wrapper, 'foo', false);
+      const falsyResults = toHaveState(wrapper, 'foo', true);
 
-  it('can validate the value also', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper).toHaveState('foo', false);
-  });
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
 
-    expect(wrapper).not.toHaveState('foo', true);
-  });
+    describe('notToHaveState', () => {
+      const wrapper = mount(<Fixture />);
+      const falsyResults = notToHaveState(wrapper, 'foo', false);
+      const truthyResults = notToHaveState(wrapper, 'foo', true);
 
-  it('can validate arrays', () => {
-    const wrapper = shallow(<Fixture />);
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
 
-    expect(wrapper).toHaveState('array', [1, 2, 3]);
-  });
-
-  it('can validate objects', () => {
-    const wrapper = shallow(<Fixture />);
-
-    expect(wrapper).toHaveState('object', { foo: 'bar' });
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toHaveState--tests.js
+++ b/src/assertions/__tests__/toHaveState--tests.js
@@ -71,7 +71,7 @@ describe('toHaveState', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -86,7 +86,7 @@ describe('toHaveState', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toHaveStyle--tests.js
+++ b/src/assertions/__tests__/toHaveStyle--tests.js
@@ -45,7 +45,7 @@ describe('toHaveStyle', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -60,7 +60,7 @@ describe('toHaveStyle', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toHaveStyle--tests.js
+++ b/src/assertions/__tests__/toHaveStyle--tests.js
@@ -1,6 +1,11 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toHaveStyle,
+  negativeCompare: notToHaveStyle,
+} = require('../toHaveStyle').toHaveStyle(jasmine.matchersUtil, []);
+
 function Fixture() {
   const style1 = { height: '100%' };
   const style2 = { flex: 8 };
@@ -14,15 +19,49 @@ function Fixture() {
 }
 
 describe('toHaveStyle', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#style1')).toHaveStyle('height', '100%');
-    expect(wrapper.find('#style2')).toHaveStyle('flex', 8);
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#style1')).toHaveStyle('height', '100%');
+      expect(wrapper.find('#style2')).toHaveStyle('flex', 8);
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('#style1')).toHaveStyle('height', '100%');
+      expect(wrapper.find('#style2')).toHaveStyle('flex', 8);
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('#style1')).toHaveStyle('height', '100%');
-    expect(wrapper.find('#style2')).toHaveStyle('flex', 8);
+  describe('unit-tests', () => {
+    describe('toHaveStyle', () => {
+      const wrapper = mount(<Fixture />).find('#style1');
+      const truthyResults = toHaveStyle(wrapper, 'height', '100%');
+      const falsyResults = toHaveStyle(wrapper, 'height', '0');
+
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
+
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('notToHaveStyle', () => {
+      const wrapper = mount(<Fixture />).find('#style1');
+      const falsyResults = notToHaveStyle(wrapper, 'height', '100%');
+      const truthyResults = notToHaveStyle(wrapper, 'height', '0');
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toHaveTagName--tests.js
+++ b/src/assertions/__tests__/toHaveTagName--tests.js
@@ -1,6 +1,10 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
-const { toHaveTagName } = require('../toHaveTagName');
+
+const {
+  compare: toHaveTagName,
+  negativeCompare: notToHaveTagName,
+} = require('../toHaveTagName').toHaveTagName(jasmine.matchersUtil, []);
 
 function Fixture() {
   return (
@@ -13,30 +17,63 @@ function Fixture() {
 }
 
 describe('toHaveTagName', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#span')).toHaveTagName('span');
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#span')).toHaveTagName('span');
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('#span')).toHaveTagName('span');
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#a')).not.toHaveTagName('span');
+    });
+
+    it('gives a specific error when trying to find for multiple nodes', () => {
+      const wrapper = shallow(<Fixture />);
+
+      const result = toHaveTagName(wrapper.find('span'), 'span');
+
+      expect(result.pass).toBeFalsy();
+      expect(result.message).toBe(
+        'Cannot verify tag name on a wrapper of multiple nodes. Found 2 nodes.'
+      );
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('#span')).toHaveTagName('span');
-  });
+  describe('unit-tests', () => {
+    describe('toHaveTagName', () => {
+      const wrapper = mount(<Fixture />).find('a');
+      const truthyResults = toHaveTagName(wrapper, 'a');
+      const falsyResults = toHaveTagName(wrapper, 'span');
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#a')).not.toHaveTagName('span');
-  });
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
 
-  it('gives a specific error when trying to find for multiple nodes', () => {
-    const wrapper = shallow(<Fixture />);
-    const { compare } = toHaveTagName();
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
 
-    const result = compare(wrapper.find('span'), 'span');
+    describe('notToHaveTagName', () => {
+      const wrapper = mount(<Fixture />).find('a');
+      const falsyResults = notToHaveTagName(wrapper, 'a');
+      const truthyResults = notToHaveTagName(wrapper, 'span');
 
-    expect(result.pass).toBeFalsy();
-    expect(result.message).toBe(
-      'Cannot verify tag name on a wrapper of multiple nodes. Found 2 nodes.'
-    );
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toHaveTagName--tests.js
+++ b/src/assertions/__tests__/toHaveTagName--tests.js
@@ -57,7 +57,7 @@ describe('toHaveTagName', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -72,7 +72,7 @@ describe('toHaveTagName', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toHaveText--test.js
+++ b/src/assertions/__tests__/toHaveText--test.js
@@ -1,6 +1,11 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toHaveText,
+  negativeCompare: notToHaveText,
+} = require('../toHaveText').toHaveText(jasmine.matchersUtil, []);
+
 function Fixture() {
   return (
     <div>
@@ -11,21 +16,55 @@ function Fixture() {
 }
 
 describe('toHaveText', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#full')).toHaveText('Test');
-    expect(wrapper.find('#full')).toHaveText();
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#full')).toHaveText('Test');
+      expect(wrapper.find('#full')).toHaveText();
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('#full')).toHaveText('Test');
+      expect(wrapper.find('#full')).toHaveText();
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#full')).not.toHaveText('Wrong');
+      expect(wrapper.find('#empty')).not.toHaveText();
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('#full')).toHaveText('Test');
-    expect(wrapper.find('#full')).toHaveText();
-  });
+  describe('unit-tests', () => {
+    describe('toHaveText', () => {
+      const wrapper = mount(<Fixture />).find('#full');
+      const truthyResults = toHaveText(wrapper, 'Test');
+      const falsyResults = toHaveText(wrapper, 'Turdz');
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#full')).not.toHaveText('Wrong');
-    expect(wrapper.find('#empty')).not.toHaveText();
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
+
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('notToHaveText', () => {
+      const wrapper = mount(<Fixture />).find('#full');
+      const falsyResults = notToHaveText(wrapper, 'Test');
+      const truthyResults = notToHaveText(wrapper, 'Turdz');
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toHaveText--test.js
+++ b/src/assertions/__tests__/toHaveText--test.js
@@ -48,7 +48,7 @@ describe('toHaveText', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -63,7 +63,7 @@ describe('toHaveText', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toHaveValue--tests.js
+++ b/src/assertions/__tests__/toHaveValue--tests.js
@@ -51,7 +51,7 @@ describe('toHaveValue', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -66,7 +66,7 @@ describe('toHaveValue', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/__tests__/toHaveValue--tests.js
+++ b/src/assertions/__tests__/toHaveValue--tests.js
@@ -1,6 +1,11 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toHaveValue,
+  negativeCompare: notToHaveValue,
+} = require('../toHaveValue').toHaveValue(jasmine.matchersUtil, []);
+
 function Fixture() {
   return (
     <div>
@@ -11,24 +16,58 @@ function Fixture() {
 }
 
 describe('toHaveValue', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('input').first()).toHaveValue('test');
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('input').first()).toHaveValue('test');
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+      expect(wrapper.find('input').first()).toHaveValue('test');
+    });
+
+    it('prioritizes `value', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('input').at(1)).toHaveValue('bar');
+      expect(wrapper.find('input').at(1)).not.toHaveValue('foo');
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('input').first()).not.toHaveValue('foo');
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
-    expect(wrapper.find('input').first()).toHaveValue('test');
-  });
+  describe('unit-tests', () => {
+    describe('toHaveValue', () => {
+      const wrapper = mount(<Fixture />).find('input').first();
+      const truthyResults = toHaveValue(wrapper, 'test');
+      const falsyResults = toHaveValue(wrapper, 'Turdz');
 
-  it('prioritizes `value', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('input').at(1)).toHaveValue('bar');
-    expect(wrapper.find('input').at(1)).not.toHaveValue('foo');
-  });
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('input').first()).not.toHaveValue('foo');
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('notToHaveValue', () => {
+      const wrapper = mount(<Fixture />).find('input').first();
+      const falsyResults = notToHaveValue(wrapper, 'test');
+      const truthyResults = notToHaveValue(wrapper, 'Turdz');
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toMatchSelector--tests.js
+++ b/src/assertions/__tests__/toMatchSelector--tests.js
@@ -1,6 +1,11 @@
 const { shallow, mount } = require('enzyme');
 const React = require('react');
 
+const {
+  compare: toMatchSelector,
+  negativeCompare: notToMatchSelector,
+} = require('../toMatchSelector').toMatchSelector(jasmine.matchersUtil, []);
+
 function Fixture() {
   return (
     <div>
@@ -10,24 +15,58 @@ function Fixture() {
 }
 
 describe('toMatchSelector', () => {
-  it('works with `shallow` renders', () => {
-    const wrapper = shallow(<Fixture />);
+  describe('integration', () => {
+    it('works with `shallow` renders', () => {
+      const wrapper = shallow(<Fixture />);
 
-    expect(wrapper.find('#child')).toMatchSelector('span');
-    expect(wrapper.find('#child')).toMatchSelector('#child');
-    expect(wrapper.find('#child')).toMatchSelector('.foo');
+      expect(wrapper.find('#child')).toMatchSelector('span');
+      expect(wrapper.find('#child')).toMatchSelector('#child');
+      expect(wrapper.find('#child')).toMatchSelector('.foo');
+    });
+
+    it('works with `mount` renders', () => {
+      const wrapper = mount(<Fixture />);
+
+      expect(wrapper.find('#child')).toMatchSelector('span');
+      expect(wrapper.find('#child')).toMatchSelector('#child');
+      expect(wrapper.find('#child')).toMatchSelector('.foo');
+    });
+
+    it('works with with jasmines negation', () => {
+      const wrapper = shallow(<Fixture />);
+      expect(wrapper.find('#child')).not.toMatchSelector('ball');
+    });
   });
 
-  it('works with `mount` renders', () => {
-    const wrapper = mount(<Fixture />);
+  describe('unit-tests', () => {
+    describe('toMatchSelector', () => {
+      const wrapper = mount(<Fixture />).find('#child');
+      const truthyResults = toMatchSelector(wrapper, '#child');
+      const falsyResults = toMatchSelector(wrapper, '.doesnt-match');
 
-    expect(wrapper.find('#child')).toMatchSelector('span');
-    expect(wrapper.find('#child')).toMatchSelector('#child');
-    expect(wrapper.find('#child')).toMatchSelector('.foo');
-  });
+      it('passes when true', () => {
+        expect(truthyResults.pass).toBeTruthy();
+        expect(falsyResults.pass).toBeFalsy();
+      });
 
-  it('works with with jasmines negation', () => {
-    const wrapper = shallow(<Fixture />);
-    expect(wrapper.find('#child')).not.toMatchSelector('ball');
+      it('\'s message is non-negative', () => {
+        expect(truthyResults.message).not.toContain('not')
+      });
+    });
+
+    describe('notToMatchSelector', () => {
+      const wrapper = mount(<Fixture />).find('#child');
+      const falsyResults = notToMatchSelector(wrapper, '#child');
+      const truthyResults = notToMatchSelector(wrapper, '.doesnt-match');
+
+      it('passes when false', () => {
+        expect(falsyResults.pass).toBeFalsy();
+        expect(truthyResults.pass).toBeTruthy();
+      });
+
+      it('\'s message is negative', () => {
+        expect(truthyResults.message).toContain('not')
+      });
+    });
   });
 });

--- a/src/assertions/__tests__/toMatchSelector--tests.js
+++ b/src/assertions/__tests__/toMatchSelector--tests.js
@@ -50,7 +50,7 @@ describe('toMatchSelector', () => {
       });
 
       it('\'s message is non-negative', () => {
-        expect(truthyResults.message).not.toContain('not')
+        expect(truthyResults.message).not.toContain('not');
       });
     });
 
@@ -65,7 +65,7 @@ describe('toMatchSelector', () => {
       });
 
       it('\'s message is negative', () => {
-        expect(truthyResults.message).toContain('not')
+        expect(truthyResults.message).toContain('not');
       });
     });
   });

--- a/src/assertions/toBeChecked.js
+++ b/src/assertions/toBeChecked.js
@@ -7,14 +7,17 @@
  */
 
 import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
 
 export default {
-  toBeChecked() : Object {
+  toBeChecked() : MatcherMethods {
 
-    function toBeChecked(enzymeWrapper:Object) : Object  {
-      let pass = false;
+    function toBeChecked(enzymeWrapper:EnzymeObject) : Matcher {
+      let pass:boolean = false;
 
-      const props = enzymeWrapper.props();
+      const props:Object = enzymeWrapper.props();
 
       // set to the default checked
       if (props.hasOwnProperty('defaultChecked')) {
@@ -26,8 +29,6 @@ export default {
         pass = props.checked;
       }
 
-      console.log(enzymeWrapper.html());
-
       return {
         pass,
         message: `Expected "${enzymeWrapper.html()}" to be checked`,
@@ -36,12 +37,12 @@ export default {
 
 
     return {
-      compare(enzymeWrapper:Object) : Object {
+      compare(enzymeWrapper:EnzymeObject) : Matcher {
         return toBeChecked(enzymeWrapper);
       },
 
-      negativeCompare(enzymeWrapper:Object) : Object {
-        const result = toBeChecked(enzymeWrapper);
+      negateCompare(enzymeWrapper:EnzymeObject) : Matcher {
+        const result:Matcher = toBeChecked(enzymeWrapper);
 
         result.message = negateMessage(result.message);
         result.pass = !result.pass;

--- a/src/assertions/toBeChecked.js
+++ b/src/assertions/toBeChecked.js
@@ -13,7 +13,6 @@ import type { EnzymeObject } from '../types/EnzymeObject';
 
 export default {
   toBeChecked() : MatcherMethods {
-
     function toBeChecked(enzymeWrapper:EnzymeObject) : Matcher {
       let pass:boolean = false;
 
@@ -35,7 +34,6 @@ export default {
       };
     }
 
-
     return {
       compare(enzymeWrapper:EnzymeObject) : Matcher {
         return toBeChecked(enzymeWrapper);
@@ -48,7 +46,7 @@ export default {
         result.pass = !result.pass;
 
         return result;
-      }
+      },
     };
   },
 };

--- a/src/assertions/toBeChecked.js
+++ b/src/assertions/toBeChecked.js
@@ -6,29 +6,48 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+
 export default {
   toBeChecked() : Object {
+
+    function toBeChecked(enzymeWrapper:Object) : Object  {
+      let pass = false;
+
+      const props = enzymeWrapper.props();
+
+      // set to the default checked
+      if (props.hasOwnProperty('defaultChecked')) {
+        pass = props.defaultChecked;
+      }
+
+      // if it has the checked property, CHECK that.
+      if (props.hasOwnProperty('checked')) {
+        pass = props.checked;
+      }
+
+      console.log(enzymeWrapper.html());
+
+      return {
+        pass,
+        message: `Expected "${enzymeWrapper.html()}" to be checked`,
+      };
+    }
+
+
     return {
       compare(enzymeWrapper:Object) : Object {
-        let pass = false;
-
-        const props = enzymeWrapper.props();
-
-        // set to the default checked
-        if (props.hasOwnProperty('defaultChecked')) {
-          pass = props.defaultChecked;
-        }
-
-        // if it has the checked property, CHECK that.
-        if (props.hasOwnProperty('checked')) {
-          pass = props.checked;
-        }
-
-        return {
-          pass,
-          message: `Expected "${enzymeWrapper.html()}" to be checked`,
-        };
+        return toBeChecked(enzymeWrapper);
       },
+
+      negativeCompare(enzymeWrapper:Object) : Object {
+        const result = toBeChecked(enzymeWrapper);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
+      }
     };
   },
 };

--- a/src/assertions/toBeChecked.js
+++ b/src/assertions/toBeChecked.js
@@ -31,7 +31,7 @@ export default {
 
       return {
         pass,
-        message: `Expected "${enzymeWrapper.html()}" to be checked`,
+        message: `Expected "${enzymeWrapper.html()}" to be checked.`,
       };
     }
 
@@ -41,7 +41,7 @@ export default {
         return toBeChecked(enzymeWrapper);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject) : Matcher {
         const result:Matcher = toBeChecked(enzymeWrapper);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toBeDisabled.js
+++ b/src/assertions/toBeDisabled.js
@@ -7,10 +7,13 @@
  */
 
 import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
 
 export default {
-  toBeDisabled() : Object {
-    function toBeDisabled(enzymeWrapper:Object) : Object {
+  toBeDisabled() : MatcherMethods {
+    function toBeDisabled(enzymeWrapper:EnzymeObject) : Matcher {
       return {
         pass: !!enzymeWrapper.prop('disabled'),
         message: 'Expected node to be "disabled"',
@@ -19,12 +22,12 @@ export default {
 
 
     return {
-      compare(enzymeWrapper:Object) : Object {
+      compare(enzymeWrapper:EnzymeObject) : Matcher {
         return toBeDisabled(enzymeWrapper);
       },
 
-      negativeCompare(enzymeWrapper:Object) : Object {
-        const result = toBeDisabled(enzymeWrapper);
+      negateCompare(enzymeWrapper:EnzymeObject) : Matcher {
+        const result:Matcher = toBeDisabled(enzymeWrapper);
 
         result.message = negateMessage(result.message);
         result.pass = !result.pass;

--- a/src/assertions/toBeDisabled.js
+++ b/src/assertions/toBeDisabled.js
@@ -16,7 +16,7 @@ export default {
     function toBeDisabled(enzymeWrapper:EnzymeObject) : Matcher {
       return {
         pass: !!enzymeWrapper.prop('disabled'),
-        message: 'Expected node to be "disabled"',
+        message: 'Expected node to be "disabled."',
       };
     }
 
@@ -26,7 +26,7 @@ export default {
         return toBeDisabled(enzymeWrapper);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject) : Matcher {
         const result:Matcher = toBeDisabled(enzymeWrapper);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toBeDisabled.js
+++ b/src/assertions/toBeDisabled.js
@@ -33,7 +33,7 @@ export default {
         result.pass = !result.pass;
 
         return result;
-      }
+      },
     };
   },
 };

--- a/src/assertions/toBeDisabled.js
+++ b/src/assertions/toBeDisabled.js
@@ -6,15 +6,31 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+
 export default {
   toBeDisabled() : Object {
+    function toBeDisabled(enzymeWrapper:Object) : Object {
+      return {
+        pass: !!enzymeWrapper.prop('disabled'),
+        message: 'Expected node to be "disabled"',
+      };
+    }
+
+
     return {
       compare(enzymeWrapper:Object) : Object {
-        return {
-          pass: !!enzymeWrapper.prop('disabled'),
-          message: 'Expected node to be "disabled"',
-        };
+        return toBeDisabled(enzymeWrapper);
       },
+
+      negativeCompare(enzymeWrapper:Object) : Object {
+        const result = toBeDisabled(enzymeWrapper);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
+      }
     };
   },
 };

--- a/src/assertions/toBeEmpty.js
+++ b/src/assertions/toBeEmpty.js
@@ -16,7 +16,7 @@ export default {
     function toBeEmpty(enzymeWrapper:EnzymeObject) : Matcher {
       return {
         pass: enzymeWrapper.length === 0,
-        message: `Expected selector to return an empty set, but found ${enzymeWrapper.length} nodes.`,
+        message: `Expected selector to return an empty set, but found ${enzymeWrapper.length} nodes.`, // eslint-disable-line max-len
       };
     }
 

--- a/src/assertions/toBeEmpty.js
+++ b/src/assertions/toBeEmpty.js
@@ -6,14 +6,32 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
 export default {
-  toBeEmpty() : Object {
+  toBeEmpty() : MatcherMethods {
+    function toBeEmpty(enzymeWrapper:EnzymeObject) : Matcher {
+      return {
+        pass: enzymeWrapper.length === 0,
+        message: `Expected selector to return an empty set, but found ${enzymeWrapper.length} nodes.`,
+      };
+    }
+
     return {
-      compare(enzymeWrapper:Object) : Object {
-        return {
-          pass: enzymeWrapper.length === 0,
-          message: `Expected contents to be empty, but it has ${enzymeWrapper.length} children`,
-        };
+      compare(enzymeWrapper:EnzymeObject) : Matcher {
+        return toBeEmpty(enzymeWrapper);
+      },
+
+      negateCompare(enzymeWrapper:EnzymeObject) : Matcher {
+        const result:Matcher = toBeEmpty(enzymeWrapper);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
       },
     };
   },

--- a/src/assertions/toBeEmpty.js
+++ b/src/assertions/toBeEmpty.js
@@ -25,7 +25,7 @@ export default {
         return toBeEmpty(enzymeWrapper);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject) : Matcher {
         const result:Matcher = toBeEmpty(enzymeWrapper);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toBePresent.js
+++ b/src/assertions/toBePresent.js
@@ -6,15 +6,33 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
+
 export default {
-  toBePresent() : Object {
+  toBePresent() : MatcherMethods {
+    function toBePresent(enzymeWrapper:EnzymeObject) : Matcher {
+      return {
+        pass: enzymeWrapper.length !== 0,
+        message: 'Expected contents to not be empty, but it is',
+      };
+    }
     return {
-      compare(enzymeWrapper:Object) : Object {
-        return {
-          pass: enzymeWrapper.length !== 0,
-          message: 'Expected contents to not be empty, but it is',
-        };
+      compare(enzymeWrapper:EnzymeObject) : Matcher {
+        return toBePresent(enzymeWrapper);
       },
+
+      negateCompare(enzymeWrapper:EnzymeObject) : Matcher {
+        const result:Matcher = toBePresent(enzymeWrapper);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+        
+        return result;
+      }
     };
   },
 };

--- a/src/assertions/toBePresent.js
+++ b/src/assertions/toBePresent.js
@@ -30,9 +30,9 @@ export default {
 
         result.message = negateMessage(result.message);
         result.pass = !result.pass;
-        
+
         return result;
-      }
+      },
     };
   },
 };

--- a/src/assertions/toBePresent.js
+++ b/src/assertions/toBePresent.js
@@ -17,7 +17,7 @@ export default {
     function toBePresent(enzymeWrapper:EnzymeObject) : Matcher {
       return {
         pass: enzymeWrapper.length !== 0,
-        message: 'Expected contents to not be empty, but it is',
+        message: 'Expected selector results to contain at least one node.',
       };
     }
     return {
@@ -25,7 +25,7 @@ export default {
         return toBePresent(enzymeWrapper);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject) : Matcher {
         const result:Matcher = toBePresent(enzymeWrapper);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toContainReact.js
+++ b/src/assertions/toContainReact.js
@@ -7,17 +7,34 @@
  */
 
 import { shallow } from 'enzyme';
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
 
 export default {
-  toContainReact() : Object {
-    return {
-      compare(enzymeWrapper:Object, reactInstance:Object) : Object {
-        const wrappedInstance = shallow(reactInstance);
+  toContainReact() : MatcherMethods {
+    function toContainReact(enzymeWrapper:EnzymeObject, reactInstance:Object) : Matcher {
+      const wrappedInstance:EnzymeObject = shallow(reactInstance);
 
-        return {
-          pass: enzymeWrapper.contains(reactInstance),
-          message: `Expected wrapper to contain ${wrappedInstance.html()}.`,
-        };
+      return {
+        pass: enzymeWrapper.contains(reactInstance),
+        message: `Expected wrapper to contain ${wrappedInstance.html()}.`,
+      };
+    }
+
+    return {
+      compare(enzymeWrapper:EnzymeObject, reactInstance:Object) : Matcher {
+        return toContainReact(enzymeWrapper, reactInstance);
+      },
+
+      negateCompare(enzymeWrapper:EnzymeObject, reactInstance:Object) : Matcher {
+        const result:Matcher = toContainReact(enzymeWrapper, reactInstance);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
       },
     };
   },

--- a/src/assertions/toContainReact.js
+++ b/src/assertions/toContainReact.js
@@ -28,7 +28,7 @@ export default {
         return toContainReact(enzymeWrapper, reactInstance);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, reactInstance:Object) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, reactInstance:Object) : Matcher {
         const result:Matcher = toContainReact(enzymeWrapper, reactInstance);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toHaveClassName.js
+++ b/src/assertions/toHaveClassName.js
@@ -6,20 +6,38 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
 export default {
-  toHaveClassName() : Object {
+  toHaveClassName() : MatcherMethods {
+    function toHaveClassName(enzymeWrapper:EnzymeObject, className:string) : Matcher {
+      let normalizedClassName = className.split(' ').join('.');
+
+      if (normalizedClassName[0] !== '.') {
+        normalizedClassName = `.${normalizedClassName}`;
+      }
+
+      return {
+        pass: enzymeWrapper.is(normalizedClassName),
+        message: `Expected "${enzymeWrapper.html()}" to have className of ${className} but instead found ${enzymeWrapper.props('className')}`, // eslint-disable-line max-len
+      };
+    }
+
     return {
-      compare(enzymeWrapper:Object, className:string) : Object {
-        let normalizedClassName = className.split(' ').join('.');
+      compare(enzymeWrapper:EnzymeObject, className:string) : Matcher {
+        return toHaveClassName(enzymeWrapper, className);
+      },
 
-        if (normalizedClassName[0] !== '.') {
-          normalizedClassName = `.${normalizedClassName}`;
-        }
+      negateCompare(enzymeWrapper:EnzymeObject, className:string) : Matcher {
+        const result:Matcher = toHaveClassName(enzymeWrapper, className);
 
-        return {
-          pass: enzymeWrapper.is(normalizedClassName),
-          message: `Expected "${enzymeWrapper.html()}" to have className of ${className} but instead found ${enzymeWrapper.props('className')}`, // eslint-disable-line max-len
-        };
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
       },
     };
   },

--- a/src/assertions/toHaveClassName.js
+++ b/src/assertions/toHaveClassName.js
@@ -31,7 +31,7 @@ export default {
         return toHaveClassName(enzymeWrapper, className);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, className:string) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, className:string) : Matcher {
         const result:Matcher = toHaveClassName(enzymeWrapper, className);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toHaveHTML.js
+++ b/src/assertions/toHaveHTML.js
@@ -6,22 +6,40 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
 export default {
-  toHaveHTML() : Object {
+  toHaveHTML() : MatcherMethods {
+    function toHaveHTML(enzymeWrapper:EnzymeObject, html:string) : Matcher {
+      const wrapperHTML = enzymeWrapper.html();
+
+      // normalize quotes
+      const useSingleQuotes = html.search("'") !== -1;
+
+      const actualHTML = wrapperHTML.replace(/("|')/g, useSingleQuotes ? "'" : '"');
+      const expectedHTML = html.replace(/("|')/g, useSingleQuotes ? "'" : '"');
+
+      return {
+        pass: actualHTML === expectedHTML,
+        message: `Expected "${actualHTML}" to equal ${expectedHTML}`,
+      };
+    }
+
     return {
-      compare(enzymeWrapper:Object, html:string) : Object {
-        const wrapperHTML = enzymeWrapper.html();
+      compare(enzymeWrapper:EnzymeObject, html:string) : Matcher {
+        return toHaveHTML(enzymeWrapper, html);
+      },
 
-        // normalize quotes
-        const useSingleQuotes = html.search("'") !== -1;
+      negateCompare(enzymeWrapper:EnzymeObject, html:string) : Matcher {
+        const result:Matcher = toHaveHTML(enzymeWrapper, html);
 
-        const actualHTML = wrapperHTML.replace(/("|')/g, useSingleQuotes ? "'" : '"');
-        const expectedHTML = html.replace(/("|')/g, useSingleQuotes ? "'" : '"');
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
 
-        return {
-          pass: actualHTML === expectedHTML,
-          message: `Expected "${actualHTML}" to equal ${expectedHTML}`,
-        };
+        return result;
       },
     };
   },

--- a/src/assertions/toHaveHTML.js
+++ b/src/assertions/toHaveHTML.js
@@ -33,7 +33,7 @@ export default {
         return toHaveHTML(enzymeWrapper, html);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, html:string) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, html:string) : Matcher {
         const result:Matcher = toHaveHTML(enzymeWrapper, html);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toHaveProp.js
+++ b/src/assertions/toHaveProp.js
@@ -12,7 +12,7 @@ import type { MatcherMethods } from '../types/MatcherMethods';
 import type { EnzymeObject } from '../types/EnzymeObject';
 
 export default {
-  toHaveProp(util:Object, customEqualityTesters:Object) : MatcherMethods {
+  toHaveProp(util:Object, customEqualityTesters:Array<Function>) : MatcherMethods {
     function toHaveProp(enzymeWrapper:EnzymeObject, propKey:string, propValue:?any) : Matcher {
       const props = enzymeWrapper.props();
 
@@ -48,7 +48,7 @@ export default {
         return toHaveProp(enzymeWrapper, propKey, propValue);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, propKey:string, propValue:?any) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, propKey:string, propValue:?any) : Matcher {
         const result:Matcher = toHaveProp(enzymeWrapper, propKey, propValue);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toHaveRef.js
+++ b/src/assertions/toHaveRef.js
@@ -6,10 +6,24 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
 export default {
-  toHaveRef() : Object {
+  toHaveRef() : MatcherMethods {
+    function toHaveRef(enzymeWrapper:EnzymeObject, refName:string) : Matcher {
+      const { node } = enzymeWrapper.ref(refName);
+
+      return {
+        pass: !!node,
+        message: `Expected to find a ref "${refName}"`,
+      };
+    }
+
     return {
-      compare(enzymeWrapper:Object, refName:string) : Object {
+      compare(enzymeWrapper:EnzymeObject, refName:string) : Matcher {
         // can only be used with mount, so the `ref` API should be available.
         if (typeof enzymeWrapper.ref !== 'function') {
           return {
@@ -18,12 +32,24 @@ export default {
           };
         }
 
-        const { node } = enzymeWrapper.ref(refName);
+        return toHaveRef(enzymeWrapper, refName);
+      },
 
-        return {
-          pass: !!node,
-          message: `Expected to find a ref "${refName}"`,
-        };
+      negateCompare(enzymeWrapper:EnzymeObject, refName:string) : Matcher {
+        // can only be used with mount, so the `ref` API should be available.
+        if (typeof enzymeWrapper.ref !== 'function') {
+          return {
+            pass: false,
+            message: '`toHaveRef` can only be used with enzymes `mount` method.',
+          };
+        }
+
+        const result:Matcher = toHaveRef(enzymeWrapper, refName);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
       },
     };
   },

--- a/src/assertions/toHaveRef.js
+++ b/src/assertions/toHaveRef.js
@@ -35,7 +35,7 @@ export default {
         return toHaveRef(enzymeWrapper, refName);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, refName:string) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, refName:string) : Matcher {
         // can only be used with mount, so the `ref` API should be available.
         if (typeof enzymeWrapper.ref !== 'function') {
           return {

--- a/src/assertions/toHaveState.js
+++ b/src/assertions/toHaveState.js
@@ -48,7 +48,7 @@ export default {
         return toHaveState(enzymeWrapper, stateKey, stateValue);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, stateKey:string, stateValue:?any) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, stateKey:string, stateValue:?any) : Matcher {
         const result:Matcher = toHaveState(enzymeWrapper, stateKey, stateValue);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toHaveState.js
+++ b/src/assertions/toHaveState.js
@@ -6,36 +6,55 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
 export default {
-  toHaveState(util:Object, customEqualityTesters:Object) : Object {
-    return {
-      compare(enzymeWrapper:Object, stateKey:string, stateValue:any) : Object {
-        const state = enzymeWrapper.state();
+  toHaveState(util:Object, customEqualityTesters:Object) : MatcherMethods {
+    function toHaveState(enzymeWrapper:EnzymeObject, stateKey:string, stateValue:?any) : Matcher {
+      const state = enzymeWrapper.state();
 
-        // error if the state key doesnt exist
-        if (!state.hasOwnProperty(stateKey)) {
-          return {
-            pass: false,
-            message: `Expected component state to have key of "${stateKey}"`,
-          };
-        }
-
-        // key exists given above check, and we're not validating over values,
-        // so its always true
-        if (stateValue === undefined) {
-          return {
-            pass: true,
-          };
-        }
-
+      // error if the state key doesnt exist
+      if (!state.hasOwnProperty(stateKey)) {
         return {
-          pass: util.equals(state[stateKey], stateValue, customEqualityTesters),
-          message: `
-            Expected component state values to match for key "${stateKey}":
-            Actual: ${JSON.stringify(state)}
-            Expected: ${JSON.stringify(stateValue)}
-          `,
+          pass: false,
+          message: `Expected component state to have key of "${stateKey}"`,
         };
+      }
+
+      // key exists given above check, and we're not validating over values,
+      // so its always true
+      if (stateValue === undefined) {
+        return {
+          pass: true,
+          message: `Expected component state to have key of "${stateKey}"`,
+        };
+      }
+
+      return {
+        pass: util.equals(state[stateKey], stateValue, customEqualityTesters),
+        message: `
+          Expected component state values to match for key "${stateKey}":
+          Actual: ${JSON.stringify(state)}
+          Expected: ${JSON.stringify(stateValue)}
+        `,
+      };
+    }
+
+    return {
+      compare(enzymeWrapper:EnzymeObject, stateKey:string, stateValue:?any) : Matcher {
+        return toHaveState(enzymeWrapper, stateKey, stateValue);
+      },
+
+      negateCompare(enzymeWrapper:EnzymeObject, stateKey:string, stateValue:?any) : Matcher {
+        const result:Matcher = toHaveState(enzymeWrapper, stateKey, stateValue);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
       },
     };
   },

--- a/src/assertions/toHaveStyle.js
+++ b/src/assertions/toHaveStyle.js
@@ -6,36 +6,53 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
 export default {
-  toHaveStyle(util:Object, customEqualityTesters:Object) : Object {
-    return {
-      compare(enzymeWrapper:Object, styleKey:string, styleValue:any) : Object {
-        const style = enzymeWrapper.prop('style');
+  toHaveStyle(util:Object, customEqualityTesters:Object) : MatcherMethods {
+    function toHaveStyle(enzymeWrapper:EnzymeObject, styleKey:string, styleValue:?any) : Matcher {
+      const style = enzymeWrapper.prop('style');
 
-        // error if component doesnt have style
-        if (!style) {
-          return {
-            pass: false,
-            message: 'Expected component to have a style prop',
-          };
-        }
-
-        // error if the style key doesnt exist
-        if (!style.hasOwnProperty(styleKey)) {
-          return {
-            pass: false,
-            message: `Expected component to have style key of "${styleKey}"`,
-          };
-        }
-
+      // error if component doesnt have style
+      if (!style) {
         return {
-          pass: util.equals(style[styleKey], styleValue, customEqualityTesters),
-          message: `
-            Expected component style values to match for key "${styleKey}":
-            Actual: ${style[styleKey]}
-            Expected: ${styleValue}
-          `,
+          pass: false,
+          message: 'Expected component to have a style prop',
         };
+      }
+
+      // error if the style key doesnt exist
+      if (!style.hasOwnProperty(styleKey)) {
+        return {
+          pass: false,
+          message: `Expected component to have style key of "${styleKey}"`,
+        };
+      }
+
+      return {
+        pass: util.equals(style[styleKey], styleValue, customEqualityTesters),
+        message: `
+          Expected component style values to match for key "${styleKey}":
+          Actual: ${style[styleKey]}
+          Expected: ${styleValue}
+        `,
+      };
+    }
+    return {
+      compare(enzymeWrapper:EnzymeObject, styleKey:string, styleValue:?any) : Matcher {
+        return toHaveStyle(enzymeWrapper, styleKey, styleValue);
+      },
+
+      negateCompare(enzymeWrapper:EnzymeObject, styleKey:string, styleValue:?any) : Matcher {
+        const result:Matcher = toHaveStyle(enzymeWrapper, styleKey, styleValue);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
       },
     };
   },

--- a/src/assertions/toHaveStyle.js
+++ b/src/assertions/toHaveStyle.js
@@ -46,7 +46,7 @@ export default {
         return toHaveStyle(enzymeWrapper, styleKey, styleValue);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, styleKey:string, styleValue:?any) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, styleKey:string, styleValue:?any) : Matcher {
         const result:Matcher = toHaveStyle(enzymeWrapper, styleKey, styleValue);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toHaveTagName.js
+++ b/src/assertions/toHaveTagName.js
@@ -6,22 +6,40 @@
  * @flow
  */
 
-export default {
-  toHaveTagName() : Object {
-    return {
-      compare(enzymeWrapper:Object, tag:string) : Object {
-        if (enzymeWrapper.nodes.length > 1) {
-          return {
-            pass: false,
-            message: `Cannot verify tag name on a wrapper of multiple nodes. Found ${enzymeWrapper.length} nodes.`, // eslint-disable-line max-len
-          };
-        }
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
 
+export default {
+  toHaveTagName() : MatcherMethods {
+    function toHaveTagName(enzymeWrapper:EnzymeObject, tag:string) : Matcher {
+      if (enzymeWrapper.nodes.length > 1) {
         return {
-          pass: enzymeWrapper.type() === tag,
-          message: `Expected node to be of type "${tag}".`,
+          pass: false,
+          message: `Cannot verify tag name on a wrapper of multiple nodes. Found ${enzymeWrapper.length} nodes.`, // eslint-disable-line max-len
         };
+      }
+
+      return {
+        pass: enzymeWrapper.type() === tag,
+        message: `Expected node to be of type "${tag}".`,
+      };
+    }
+
+    return {
+      compare(enzymeWrapper:EnzymeObject, tag:string) : Matcher {
+        return toHaveTagName(enzymeWrapper, tag);
       },
+
+      negateCompare(enzymeWrapper:EnzymeObject, tag:string) : Matcher {
+        const result:Matcher = toHaveTagName(enzymeWrapper, tag);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
+      }
     };
   },
 };

--- a/src/assertions/toHaveTagName.js
+++ b/src/assertions/toHaveTagName.js
@@ -32,7 +32,7 @@ export default {
         return toHaveTagName(enzymeWrapper, tag);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, tag:string) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, tag:string) : Matcher {
         const result:Matcher = toHaveTagName(enzymeWrapper, tag);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toHaveTagName.js
+++ b/src/assertions/toHaveTagName.js
@@ -39,7 +39,7 @@ export default {
         result.pass = !result.pass;
 
         return result;
-      }
+      },
     };
   },
 };

--- a/src/assertions/toHaveText.js
+++ b/src/assertions/toHaveText.js
@@ -34,7 +34,7 @@ export default {
         return toHaveText(enzymeWrapper, text);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, text:?string) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, text:?string) : Matcher {
         const result:Matcher = toHaveText(enzymeWrapper, text);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toHaveText.js
+++ b/src/assertions/toHaveText.js
@@ -6,23 +6,41 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
 export default {
-  toHaveText() : Object {
-    return {
-      compare(enzymeWrapper:Object, text:?string) : Object {
-        const actualText = enzymeWrapper.text();
+  toHaveText() : MatcherMethods {
+    function toHaveText(enzymeWrapper:EnzymeObject, text:?string) : Matcher {
+      const actualText = enzymeWrapper.text();
 
-        if (text === undefined) {
-          return {
-            pass: actualText.length > 0,
-            message: 'Expected node to have text',
-          };
-        }
-
+      if (text === undefined) {
         return {
-          pass: actualText === text,
-          message: `Expected "${actualText}" to equal "${text}"`,
+          pass: actualText.length > 0,
+          message: 'Expected node to have text',
         };
+      }
+
+      return {
+        pass: actualText === text,
+        message: `Expected "${actualText}" to equal "${text}"`,
+      };
+    }
+
+    return {
+      compare(enzymeWrapper:EnzymeObject, text:?string) : Matcher {
+        return toHaveText(enzymeWrapper, text);
+      },
+
+      negateCompare(enzymeWrapper:EnzymeObject, text:?string) : Matcher {
+        const result:Matcher = toHaveText(enzymeWrapper, text);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
       },
     };
   },

--- a/src/assertions/toHaveValue.js
+++ b/src/assertions/toHaveValue.js
@@ -39,7 +39,7 @@ export default {
         return toHaveValue(enzymeWrapper, expectedValue);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, expectedValue:any) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, expectedValue:any) : Matcher {
         const result:Matcher = toHaveValue(enzymeWrapper, expectedValue);
 
         result.message = negateMessage(result.message);

--- a/src/assertions/toHaveValue.js
+++ b/src/assertions/toHaveValue.js
@@ -6,28 +6,46 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
 export default {
-  toHaveValue() : Object {
+  toHaveValue() : MatcherMethods {
+    function toHaveValue(enzymeWrapper:EnzymeObject, expectedValue:any) : Matcher {
+      let pass = false;
+
+      const props = enzymeWrapper.props();
+
+      // set to the default checked
+      if (props.hasOwnProperty('defaultValue')) {
+        pass = props.defaultValue === expectedValue;
+      }
+
+      // if it has the `value` property, CHECK that
+      if (props.hasOwnProperty('value')) {
+        pass = props.value === expectedValue;
+      }
+
+      return {
+        pass,
+        message: `Expected "${enzymeWrapper.html()}" to have value of "${expectedValue}"`,
+      };
+    }
+
     return {
-      compare(enzymeWrapper:Object, expectedValue:any) : Object {
-        let pass = false;
+      compare(enzymeWrapper:EnzymeObject, expectedValue:any) : Matcher {
+        return toHaveValue(enzymeWrapper, expectedValue);
+      },
 
-        const props = enzymeWrapper.props();
+      negateCompare(enzymeWrapper:EnzymeObject, expectedValue:any) : Matcher {
+        const result:Matcher = toHaveValue(enzymeWrapper, expectedValue);
 
-        // set to the default checked
-        if (props.hasOwnProperty('defaultValue')) {
-          pass = props.defaultValue === expectedValue;
-        }
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
 
-        // if it has the `value` property, CHECK that
-        if (props.hasOwnProperty('value')) {
-          pass = props.value === expectedValue;
-        }
-
-        return {
-          pass,
-          message: `Expected "${enzymeWrapper.html()}" to have value of "${expectedValue}"`,
-        };
+        return result;
       },
     };
   },

--- a/src/assertions/toMatchSelector.js
+++ b/src/assertions/toMatchSelector.js
@@ -32,7 +32,7 @@ export default {
         result.pass = !result.pass;
 
         return result;
-      }
+      },
     };
   },
 };

--- a/src/assertions/toMatchSelector.js
+++ b/src/assertions/toMatchSelector.js
@@ -6,15 +6,33 @@
  * @flow
  */
 
+import negateMessage from '../negateMessage';
+import type { Matcher } from '../types/Matcher';
+import type { MatcherMethods } from '../types/MatcherMethods';
+import type { EnzymeObject } from '../types/EnzymeObject';
+
 export default {
-  toMatchSelector() : Object {
+  toMatchSelector() : MatcherMethods {
+    function toMatchSelector(enzymeWrapper:EnzymeObject, selector:string) : Matcher {
+      return {
+        pass: enzymeWrapper.is(selector),
+        message: `Expected to match "${selector}".`,
+      };
+    }
+
     return {
-      compare(enzymeWrapper:Object, selector:string) : Object {
-        return {
-          pass: enzymeWrapper.is(selector),
-          message: `Expected to match "${selector}".`,
-        };
+      compare(enzymeWrapper:EnzymeObject, selector:string) : Object {
+        return toMatchSelector(enzymeWrapper, selector);
       },
+
+      negateCompare(enzymeWrapper:EnzymeObject, selector: string) : Matcher {
+        const result:Matcher = toMatchSelector(enzymeWrapper, selector);
+
+        result.message = negateMessage(result.message);
+        result.pass = !result.pass;
+
+        return result;
+      }
     };
   },
 };

--- a/src/assertions/toMatchSelector.js
+++ b/src/assertions/toMatchSelector.js
@@ -25,7 +25,7 @@ export default {
         return toMatchSelector(enzymeWrapper, selector);
       },
 
-      negateCompare(enzymeWrapper:EnzymeObject, selector: string) : Matcher {
+      negativeCompare(enzymeWrapper:EnzymeObject, selector: string) : Matcher {
         const result:Matcher = toMatchSelector(enzymeWrapper, selector);
 
         result.message = negateMessage(result.message);

--- a/src/negateMessage.js
+++ b/src/negateMessage.js
@@ -2,7 +2,7 @@
  * This source code is licensed under the MIT-style license found in the
  * LICENSE file in the root directory of this source tree. *
  *
- * @providesModule negateMessage 
+ * @providesModule negateMessage
  *
  * Every message has the word "to" in it
  * to describe what was expected, we just insert

--- a/src/negateMessage.js
+++ b/src/negateMessage.js
@@ -1,0 +1,14 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule negateMessage 
+ *
+ * Every message has the word "to" in it
+ * to describe what was expected, we just insert
+ * "not" before it.
+ */
+
+export default function negateMessage(message:string) : string {
+  return message.replace(' to ', ' not to ');
+}

--- a/src/types/EnzymeObject.js
+++ b/src/types/EnzymeObject.js
@@ -1,0 +1,10 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule EnzymeObject
+ * @flow
+ */
+
+// TODO: implement type
+export type EnzymeObject = Object;

--- a/src/types/Matcher.js
+++ b/src/types/Matcher.js
@@ -1,0 +1,12 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule Matcher
+ * @flow
+ */
+
+export type Matcher = {
+  message: string,
+  pass: boolean,
+};

--- a/src/types/MatcherMethods.js
+++ b/src/types/MatcherMethods.js
@@ -8,5 +8,5 @@
 
 export type MatcherMethods = {
   compare: Function,
-  negateCompare: Function,
+  negativeCompare: Function,
 };

--- a/src/types/MatcherMethods.js
+++ b/src/types/MatcherMethods.js
@@ -1,0 +1,12 @@
+/**
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree. *
+ *
+ * @providesModule MatcherMethods
+ * @flow
+ */
+
+export type MatcherMethods = {
+  compare: Function,
+  negateCompare: Function,
+};


### PR DESCRIPTION
My first implementation was naive and didn't account for "not" style messages, leading to confusing test failures. This large PR does a very simple thing, implements `negativeCompare` and negates the results for every matcher.

I thought about making a util to wrap each one and reduce code, but I wouldn't be surprised if matchers needed one off logic in certain areas, so the boilerplate helps with that future flexibility while remaining a bit more declarative, so we'll go with it.

I'm going to leave this up for a few days and if anyone wants to test it out ahead of time they can just to make sure nothing regressed.