### PR TITLE
Docs: jest 15 disabled automock by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,19 @@ $ npm install jasmine-enzyme --save-dev
 
 ### Jest
 If you are using [jest](https://facebook.github.io/jest/), the simplest setup
-is to use jest's `setupTestFrameworkScriptFile` config. You'll also need to
-tell jest to unmock `react`, `enzyme`, and `jasmine-enzyme`.
+is to use jest's `setupTestFrameworkScriptFile` config.
 
 Make sure your `package.json` includes the following:
 
-```js
+```json
+"jest": {
+  "setupTestFrameworkScriptFile": "node_modules/jasmine-enzyme/lib/jest.js"
+},
+```
+
+If you are using a jest version lower than `15` you'll also need to tell it to unmock `react`, `enzyme`, and `jasmine-enzyme`.
+
+```json
 "jest": {
   "setupTestFrameworkScriptFile": "node_modules/jasmine-enzyme/lib/jest.js",
   "unmockedModulePathPatterns": [


### PR DESCRIPTION
Hi,

if we follow the setup instructions from the Readme, we get this nice warning from Jest:

```
The `unmockedModulePathPatterns` setting is defined but automocking is disabled in Jest.  
Please either remove `unmockedModulePathPatterns` from your configuration or explicitly 
set `"automock": true` in your configuration if you wish to use automocking.

  Jest 15 changed the default configuration for tests and makes Jest easier to
  use and less confusing for beginners. All previous defaults can be restored
  if your project depends on it. A comprehensive explanation of the breaking
  changes and an upgrade guide can be found in the release blog post linked
  below.

  Jest Issue Tracker: https://github.com/facebook/jest/issues
  Configuration Documentation: https://facebook.github.io/jest/docs/api.html
  Release Blog Post: https://facebook.github.io/jest/blog/2016/09/01/jest-15.html
```

This PR just higlight the different config needed depending on Jest's version.